### PR TITLE
Sonoff Basic firmware 2.6.1 is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This is just a proof of concept because I searched for it and there was no imple
 ## Compatibility list
 | Model | Supported | 1.6 | 1.8.1 | 2.6 | 2.6.1 | 2.7.1 | Remarks |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------:|:---:|:-----:|:---:|-------|:-----:|--------------------------------------------------------------------------------------------|
-| Sonoff Basic | yes | yes | yes | yes |  |  |  |
+| Sonoff Basic | yes | yes | yes | yes | yes |  |  |
 | Sonoff Dual | yes |  |  |  |  |  |  |
 | Sonoff RF | yes |  |  |  | yes |  |  |
 | Sonoff G1 | ? |  |  |  |  |  |  |


### PR DESCRIPTION
Sonoff Basic firmware 2.6.1 is supported flag set.