### PR TITLE
Modified readme to include instructions for HA 0.88+ users

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ And copy the *.py files in `custom_components` folder using the same structure l
         └── sonoff.py
 ```
 
+`Disclaimer:` If and only if on HA 0.88+, Folder structure should look like:
+```
+ custom_components
+    └── sonoff
+        └── __init__.py (this is the main sonoff.py just renamed as __init__.py)
+        └── sensor.py
+        └── switch.py
+```
+
 `email` [Deprecated] used only for compatibility, may be eliminated in future.
 
 `username` the username that you registered for ewelink account be it an email or a phone number (the phone number should lead with region number, '+8612345678901' for example).

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ And copy the *.py files in `custom_components` folder using the same structure l
 ```
  custom_components
     └── sonoff
-        └── __init__.py (this is the main sonoff.py just renamed as __init__.py)
-        └── sensor.py
-        └── switch.py
+        └── __init__.py (this is the /custom_components/sonoff.py just renamed as __init__.py)
+        └── sensor.py (this is the /custom_components/sensor/sonoff.py just renamed as sensor.py)
+        └── switch.py (this is the /custom_components/switch/sonoff.py just renamed as switch.py)
 ```
 
 `email` [Deprecated] used only for compatibility, may be eliminated in future.


### PR DESCRIPTION
According to [HA 0.88 breaking changes](https://developers.home-assistant.io/blog/2019/02/19/the-great-migration.html) for Custom components.

So all sonoff custom component files have to be in config/custom_components/sonoff folder

So move `/custom_components/sonoff.p`y to `/custom_components/sonoff` and rename to `__init__.py`
Rename `/custom_components/sensor/sonoff.py` to `sensor.py` and move to `/custom_components/sonoff/`

Similarly rename `/custom_components/switch/sonoff.py` to `switch.py` and move to `/custom_components/sonoff/ `

So final file structure should be:
```
config/custom_components/sonoff/__init__.py (this was the main sonoff.py in custom_components folder)
config/custom_components/sonoff/sensor.py
config/custom_components/sonoff/switch.py
```