### PR TITLE
Activate Grace Period if devices were properly fetched.

### DIFF
--- a/sonoff/__init__.py
+++ b/sonoff/__init__.py
@@ -356,7 +356,7 @@ class Sonoff():
         resp = r.json()
         if 'error' in resp and resp['error'] in [HTTP_BAD_REQUEST, HTTP_UNAUTHORIZED]:
             # @IMPROVE add maybe a service call / switch to deactivate sonoff component
-            if self.is_grace_period():
+            if self._devices and self.is_grace_period():
                 _LOGGER.warning("Grace period activated!")
 
                 # return the current (and possible old) state of devices


### PR DESCRIPTION
Grace period activating even with no devices in list causing HA not to register entities.

Debugging log of this fix:
```
2019-09-30 13:59:25 DEBUG (MainThread) [custom_components.sonoff] Create the main object
2019-09-30 13:59:30 INFO (MainThread) [custom_components.sonoff] Re-login component
2019-09-30 13:59:34 WARNING (MainThread) [custom_components.sonoff] Error updating 0 devices.
2019-09-30 13:59:34 INFO (MainThread) [custom_components.sonoff] Re-login component
2019-09-30 13:59:39 INFO (MainThread) [custom_components.sonoff] Found websocket address: as-pconnect2.coolkit.cc
2019-09-30 13:59:39 DEBUG (Thread-3) [custom_components.sonoff] (re)init websocket
2019-09-30 13:59:41 DEBUG (Thread-6) [custom_components.sonoff] websocket msg: {"error":0,"apikey":"cdca5c4a-df3e-49bc-af84-7376fccd4541","config":{"hb":1,"hbInterval":145},"sequence":"15698483810431004"}
2019-09-30 14:03:42 WARNING (MainThread) [custom_components.sonoff] Error updating 4 devices.
2019-09-30 14:03:42 WARNING (MainThread) [custom_components.sonoff] Grace period activated!
```