### PR TITLE
Use YAML comments in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ To setup add to your configuration.yaml:
 sonoff:
   username: [email or phone number]
   password: [password]
-  scan_interval: 60 (optional, lower values than 60 won't work anymore!)
-  grace_period: 600 (optional)
-  api_region: 'eu' (optional)
-  entity_prefix: True (optional)
-  debug: False (optional)
+  scan_interval: 60 # optional, lower values than 60 won't work anymore!
+  grace_period: 600 # optional
+  api_region: 'eu' # optional
+  entity_prefix: True # optional
+  debug: False # optional
 ```
 And copy the *.py files in `custom_components` folder using the same structure like defined here:
 ```


### PR DESCRIPTION
By using YAML comments, there are two benefits:

- The color is different which makes it easier to differentiate the value from the comment
- The example can be copied / pasted without causing errors

### Before
![image](https://user-images.githubusercontent.com/17952318/71730530-b81f4e00-2e42-11ea-9932-c90afdec03c4.png)

### After
![image](https://user-images.githubusercontent.com/17952318/71730540-bf465c00-2e42-11ea-8116-ab6e6bba4dbb.png)
